### PR TITLE
[PLT-3196] Fixup initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Wachtwoord.configure do |config|
 end
 ```
 
+Or, you can set the `WACHTWOORD_SECRETS_NAMESPACE` env.
+
 #### Secret name tokens
 
 Secret name tokens are what's used to pattern match for detecting potential plain-text secrets in your `.env` files. The configuration comes with a default list of tokens, which you can customise as needed.
@@ -60,17 +62,21 @@ Wachtwoord.configure do |config|
 end
 ```
 
-#### Allowed secret names
+Or, you can set the `WACHTWOORD_SECRET_NAME_TOKENS` env with comma-separated values.
+
+#### Allowed config names
 
 Related to the above, you can also provide an allow-list of ENV names you want to allow-list, so that they are not counted as plain-text secrets in your `.env` files.
 
-Adding an allowed secret name:
+Adding an allowed config name:
 
 ```ruby
 Wachtwoord.configure do |config|
-  config.allowed_secret_names << 'SECRET_AUTH_TOKEN_JK'
+  config.allowed_config_names << 'SECRET_AUTH_TOKEN_JK'
 end
 ```
+
+Or, you can set the `WACHTWOORD_ALLOWED_CONFIG_NAMES` env with comma-separated values.
 
 #### AWS user
 
@@ -98,8 +104,8 @@ You'll need an AWS user or role with the following access to secrets manager:
 			"Sid": "VisualEditor1",
 			"Effect": "Allow",
 			"Action": [
-				"secretsmanager:GetRandomPassword", # TODO: double check this is required
-				"secretsmanager:ListSecrets", # TODO: double check this is required
+				"secretsmanager:GetRandomPassword",
+				"secretsmanager:ListSecrets",
 				"secretsmanager:BatchGetSecretValue"
 			],
 			"Resource": "*"
@@ -118,7 +124,7 @@ potential secret in .env.production on line 74
 potential secret in .env.production on line 111
 ```
 
-Useful for pre-commit hooks, you can pass a list of filenames and it will check those files for any lines that look like they might contain plain-text secrets. It fails with a non-zero exit code and prints the offending line numbers. See also `secret_name_tokens` and `allowed_secret_names` configurations.
+Useful for pre-commit hooks, you can pass a list of filenames and it will check those files for any lines that look like they might contain plain-text secrets. It fails with a non-zero exit code and prints the offending line numbers. See also `secret_name_tokens` and `allowed_config_names` configurations.
 
 ### Adding a new secret:
 

--- a/lib/wachtwoord/configuration.rb
+++ b/lib/wachtwoord/configuration.rb
@@ -23,7 +23,7 @@ module Wachtwoord
       TOKEN
       REDIS_.*URL
     ].freeze
-    DO_NOT_IMPORT_SECRET_NAMES = %w[
+    DO_NOT_IMPORT_NAMES = %w[
       AWS_SECRET_ACCESS_KEY
       HEROKU_APP_DEFAULT_DOMAIN_NAME
       HEROKU_APP_ID
@@ -42,10 +42,10 @@ module Wachtwoord
     attr_accessor :secret_name_tokens
 
     sig { returns(T::Array[String]) }
-    attr_accessor :do_not_import_secret_names
+    attr_accessor :do_not_import_names
 
     sig { returns(T::Array[String]) }
-    attr_accessor :allowed_secret_names
+    attr_accessor :allowed_config_names
 
     sig { returns(String) }
     attr_accessor :secret_version_env_name_prefix
@@ -56,16 +56,21 @@ module Wachtwoord
     sig { returns(String) }
     attr_accessor :version_stage_prefix
 
+    sig { returns(T::Boolean) }
+    attr_accessor :enabled
+
     sig { returns(T.untyped) }
     attr_accessor :logger
 
     def initialize
-      @secret_name_tokens = SECRET_NAME_TOKENS.dup
-      @do_not_import_secret_names = DO_NOT_IMPORT_SECRET_NAMES.dup
+      @secret_name_tokens = SECRET_NAME_TOKENS.dup + ENV.fetch('WACHTWOORD_SECRET_NAME_TOKENS', '').split(',')
+      @do_not_import_names = DO_NOT_IMPORT_NAMES.dup + ENV.fetch('WACHTWOORD_DO_NOT_IMPORT_NAMES', '').split(',')
       @secret_version_env_name_prefix = SECRET_VERSION_ENV_NAME_PREFIX
-      @allowed_secret_names = []
+      @allowed_config_names = ENV.fetch('WACHTWOORD_ALLOWED_CONFIG_NAMES', '').split(',')
       @version_stage_prefix = VERSION_STAGE_PREFIX
       @logger = Logger.new($stdout)
+      @secrets_namespace = ENV.fetch('WACHTWOORD_SECRETS_NAMESPACE', nil)
+      @enabled = ENV.fetch('WACHTWOORD_ENABLED', 'true') == 'true'
     end
   end
 end

--- a/lib/wachtwoord/import.rb
+++ b/lib/wachtwoord/import.rb
@@ -9,7 +9,7 @@ module Wachtwoord
 
     sig { params(application_name: String).returns(T::Hash[String, String]) }
     def self.envs_from_heroku(application_name:)
-      JSON.parse(`heroku config -j -a #{application_name}`).except(*Wachtwoord.configuration.do_not_import_secret_names)
+      JSON.parse(`heroku config -j -a #{application_name}`)
     end
 
     sig { params(application_name: String, dotenv_file_path: String, overwrite: T::Boolean).returns(T::Array[String]) }
@@ -19,7 +19,7 @@ module Wachtwoord
 
     sig { params(envs_from_source: T::Hash[String, String], dotenv_file_path: String, overwrite: T::Boolean, override_namespace: String).void }
     def initialize(envs_from_source:, dotenv_file_path:, overwrite:, override_namespace:)
-      @envs_from_source = envs_from_source
+      @envs_from_source = envs_from_source.except(*T.unsafe(Wachtwoord.configuration.do_not_import_names))
       @dotenv_file_path = dotenv_file_path
       @overwrite = overwrite
       @override_namespace = override_namespace

--- a/lib/wachtwoord/railtie.rb
+++ b/lib/wachtwoord/railtie.rb
@@ -6,5 +6,18 @@ module Wachtwoord
     rake_tasks do
       load 'wachtwoord/secret.rake'
     end
+
+    initializer 'wachtwoord', after: 'dotenv' do |_app|
+      Wachtwoord.configure do |config|
+        config.logger = Rails.logger
+      end
+    end
+
+    config.before_configuration do
+      start_at = Time.now
+      Wachtwoord.load_secrets_into_env(clash_behaviour: :preserve_env)
+      end_at = Time.now
+      Wachtwoord.configuration.logger.info("[Wachtwoord] loaded secrets in #{end_at - start_at}s")
+    end
   end
 end

--- a/lib/wachtwoord/railtie.rb
+++ b/lib/wachtwoord/railtie.rb
@@ -14,6 +14,8 @@ module Wachtwoord
     end
 
     config.before_configuration do
+      next unless Wachtwoord.configuration.enabled
+
       start_at = Time.now
       Wachtwoord.load_secrets_into_env(clash_behaviour: :preserve_env)
       end_at = Time.now

--- a/lib/wachtwoord/secret_name_matcher.rb
+++ b/lib/wachtwoord/secret_name_matcher.rb
@@ -14,7 +14,7 @@ module Wachtwoord
 
     def initialize
       @secret_name_patterns = Wachtwoord.configuration.secret_name_tokens.map { |token| self.class.token_to_pattern(token) }
-      @normalized_allowed_secret_names = Wachtwoord.configuration.allowed_secret_names.map(&:downcase)
+      @normalized_allowed_config_names = Wachtwoord.configuration.allowed_config_names.map(&:downcase)
       @secret_version_env_name_prefix = Wachtwoord.configuration.secret_version_env_name_prefix.downcase
     end
 
@@ -24,7 +24,7 @@ module Wachtwoord
 
       normalized_name = name.strip.downcase
       return false if normalized_name.start_with?(secret_version_env_name_prefix)
-      return false if normalized_allowed_secret_names.include?(normalized_name)
+      return false if normalized_allowed_config_names.include?(normalized_name)
 
       secret_name_patterns.any? { |secret_name_pattern| normalized_name.match(secret_name_pattern) }
     end
@@ -35,7 +35,7 @@ module Wachtwoord
     attr_reader :secret_name_patterns
 
     sig { returns(T::Array[String]) }
-    attr_reader :normalized_allowed_secret_names
+    attr_reader :normalized_allowed_config_names
 
     sig { returns(String) }
     attr_reader :secret_version_env_name_prefix

--- a/test/wachtwoord/test_import.rb
+++ b/test/wachtwoord/test_import.rb
@@ -10,6 +10,7 @@ module Wachtwoord
       @namespace = 'meetcleo_production'
       Wachtwoord.configure do |config|
         config.secrets_namespace = namespace
+        config.do_not_import_names = ['CONFIG_3']
       end
       @client = mock(:client)
       @secret = Secret.new(name: 'secret_key_1')
@@ -22,7 +23,7 @@ module Wachtwoord
       expect_create_secret
 
       Tempfile.open('foo') do |dotenv_file|
-        described_class.new(envs_from_source: { 'config_1' => 'blah1', 'secret_key_1' => 'blah2', 'CONFIG_2' => "a\nb\nc" }, dotenv_file_path: dotenv_file.path, overwrite: false, override_namespace: namespace).start
+        described_class.new(envs_from_source: { 'config_1' => 'blah1', 'secret_key_1' => 'blah2', 'CONFIG_2' => "a\nb\nc", 'CONFIG_3' => 'blah3' }, dotenv_file_path: dotenv_file.path, overwrite: false, override_namespace: namespace).start
 
         assert_equal("CONFIG_1=blah1\nCONFIG_2=\"a\nb\nc\"\nSECRET_VERSION_ENV_SECRET_KEY_1=1", dotenv_file.read)
       end

--- a/test/wachtwoord/test_secret_name_matcher.rb
+++ b/test/wachtwoord/test_secret_name_matcher.rb
@@ -8,7 +8,7 @@ module Wachtwoord
     def test_that_it_respects_the_allow_list
       instance_without_allow_list = described_class.new
       Wachtwoord.configure do |config|
-        config.allowed_secret_names << 'SECRET_AUTH_TOKEN'
+        config.allowed_config_names << 'SECRET_AUTH_TOKEN'
       end
       instance_with_allow_list = described_class.new
 


### PR DESCRIPTION
Wachtwoord cannot be initialised in a regular Rails initialiser file because secrets must be loaded before the `config/database.yml` file is read. This changes how Wachtwoord is initialised by making it initialise as part of the Rails application configuration (dotenv works like this as well already).

Also, have added the ability to provide configs to Wachtwoord using ENVs. This is making it so we don't have to bosh this configuration in our application.rb file, and also allows us to share configuration with the `bin/wachtwoord` executable to manage things like secret name patterns (because the config lives in our dotenv file).