### PR TITLE
[PLT-3194] Use ENV to tweak logging level

### DIFF
--- a/lib/wachtwoord.rb
+++ b/lib/wachtwoord.rb
@@ -9,8 +9,8 @@ require_relative 'wachtwoord/configuration'
 require_relative 'wachtwoord/secret_name_matcher'
 require_relative 'wachtwoord/version_stage'
 require_relative 'wachtwoord/secret'
-require_relative 'wachtwoord/fetch'
 require_relative 'wachtwoord/manager'
+require_relative 'wachtwoord/fetch'
 require_relative 'wachtwoord/import'
 require_relative 'wachtwoord/railtie' if defined? Rails
 
@@ -50,7 +50,7 @@ module Wachtwoord
     sig { params(clash_behaviour: T.nilable(Symbol)).void }
     def load_secrets_into_env(clash_behaviour: :raise)
       clash_behaviour = T.must(clash_behaviour)
-      secret_values_by_env_name = Fetch.new(desired_version_stages_by_secret:, client:).secret_values_by_env_name
+      secret_values_by_env_name = Fetch.new(desired_version_stages_by_secret:, client:, raise_if_not_found: configuration.raise_if_secret_not_found).secret_values_by_env_name
       secret_values_by_env_name.each do |env_name, secret_value|
         new_secret_value = new_value_for_env(env_name:, secret_value:, clash_behaviour:)
         configuration.logger.debug { "[Wachtwoord] setting ENV: #{env_name}" }

--- a/lib/wachtwoord/configuration.rb
+++ b/lib/wachtwoord/configuration.rb
@@ -68,7 +68,7 @@ module Wachtwoord
       @secret_version_env_name_prefix = SECRET_VERSION_ENV_NAME_PREFIX
       @allowed_config_names = ENV.fetch('WACHTWOORD_ALLOWED_CONFIG_NAMES', '').split(',')
       @version_stage_prefix = VERSION_STAGE_PREFIX
-      @logger = Logger.new($stdout)
+      @logger = Logger.new($stdout, level: T.unsafe(ENV.fetch('LOG_LEVEL', Logger::INFO)))
       @secrets_namespace = ENV.fetch('WACHTWOORD_SECRETS_NAMESPACE', nil)
       @enabled = ENV.fetch('WACHTWOORD_ENABLED', 'true') == 'true'
     end

--- a/lib/wachtwoord/configuration.rb
+++ b/lib/wachtwoord/configuration.rb
@@ -59,6 +59,9 @@ module Wachtwoord
     sig { returns(T::Boolean) }
     attr_accessor :enabled
 
+    sig { returns(T::Boolean) }
+    attr_accessor :raise_if_secret_not_found
+
     sig { returns(T.untyped) }
     attr_accessor :logger
 
@@ -71,6 +74,7 @@ module Wachtwoord
       @logger = Logger.new($stdout, level: T.unsafe(ENV.fetch('LOG_LEVEL', Logger::INFO)))
       @secrets_namespace = ENV.fetch('WACHTWOORD_SECRETS_NAMESPACE', nil)
       @enabled = ENV.fetch('WACHTWOORD_ENABLED', 'true') == 'true'
+      @raise_if_secret_not_found = ENV.fetch('WACHTWOORD_RAISE_IF_SECRET_NOT_FOUND', 'true') == 'true'
     end
   end
 end

--- a/test/wachtwoord/test_import.rb
+++ b/test/wachtwoord/test_import.rb
@@ -73,7 +73,7 @@ module Wachtwoord
     private
 
     def expect_fetch_secret(already_exists: false)
-      errors = already_exists ? [] : [error_code: 'ResourceNotFoundException']
+      errors = already_exists ? [] : [error_code: Fetch::RESOURCE_NOT_FOUND_ERROR_CLASS_NAME]
       client.expects(:batch_get_secret_value).with({ secret_id_list: [secret.namespaced_name] }).returns(response(secret: already_exists ? secret : nil, version_stage:, errors:))
     end
 


### PR DESCRIPTION
Reads `LOG_LEVEL` to set the log level for the default logger.

Need to do this because otherwise it will clutter up our release logs with debug info.