### PR TITLE
PLT-4073 feat: ability to overwrite certain configs in preserve_env mode

### DIFF
--- a/lib/wachtwoord.rb
+++ b/lib/wachtwoord.rb
@@ -16,11 +16,13 @@ require_relative 'wachtwoord/railtie' if defined? Rails
 
 module Wachtwoord
   extend T::Sig
+
   class ChangingExistingEnvError < StandardError; end
   class UnknownClashBehaviourError < StandardError; end
 
   class << self
     extend T::Sig
+
     attr_writer :configuration
 
     sig { returns(Configuration) }

--- a/lib/wachtwoord.rb
+++ b/lib/wachtwoord.rb
@@ -89,8 +89,13 @@ module Wachtwoord
       when :raise
         raise ChangingExistingEnvError, "Unexpected change to ENV: #{env_name}"
       when :preserve_env
-        configuration.logger.warn { "[Wachtwoord] not overwriting existing ENV: #{env_name}" }
-        existing_secret_value
+        if configuration.forced_overwrite_config_names.include?(env_name)
+          configuration.logger.warn { "[Wachtwoord] (forced) overwriting existing ENV: #{env_name}" }
+          secret_value
+        else
+          configuration.logger.warn { "[Wachtwoord] not overwriting existing ENV: #{env_name}" }
+          existing_secret_value
+        end
       when :overwrite_env
         configuration.logger.warn { "[Wachtwoord] overwriting existing ENV: #{env_name}" }
         secret_value

--- a/lib/wachtwoord/configuration.rb
+++ b/lib/wachtwoord/configuration.rb
@@ -4,6 +4,7 @@
 module Wachtwoord
   class Configuration
     extend T::Sig
+
     SECRET_NAME_TOKENS = %w[
       APP_ID
       AUTH

--- a/lib/wachtwoord/configuration.rb
+++ b/lib/wachtwoord/configuration.rb
@@ -65,6 +65,9 @@ module Wachtwoord
     sig { returns(T.untyped) }
     attr_accessor :logger
 
+    sig { returns(T::Array[String]) }
+    attr_accessor :forced_overwrite_config_names
+
     def initialize
       @secret_name_tokens = SECRET_NAME_TOKENS.dup + ENV.fetch('WACHTWOORD_SECRET_NAME_TOKENS', '').split(',')
       @do_not_import_names = DO_NOT_IMPORT_NAMES.dup + ENV.fetch('WACHTWOORD_DO_NOT_IMPORT_NAMES', '').split(',')
@@ -75,6 +78,7 @@ module Wachtwoord
       @secrets_namespace = ENV.fetch('WACHTWOORD_SECRETS_NAMESPACE', nil)
       @enabled = ENV.fetch('WACHTWOORD_ENABLED', 'true') == 'true'
       @raise_if_secret_not_found = ENV.fetch('WACHTWOORD_RAISE_IF_SECRET_NOT_FOUND', 'true') == 'true'
+      @forced_overwrite_config_names = ENV.fetch('WACHTWOORD_FORCED_OVERWRITE_CONFIG_NAMES', '').split(',')
     end
   end
 end

--- a/lib/wachtwoord/fetch.rb
+++ b/lib/wachtwoord/fetch.rb
@@ -9,6 +9,7 @@
 module Wachtwoord
   class Fetch
     extend T::Sig
+
     class MissingSecretsError < StandardError; end
     class AdditionalSecretsError < StandardError; end
     class FetchingSecretsError < StandardError; end

--- a/lib/wachtwoord/import.rb
+++ b/lib/wachtwoord/import.rb
@@ -4,6 +4,7 @@
 module Wachtwoord
   class Import
     extend T::Sig
+
     class ExistingSecretError < StandardError; end
     class ExistingConfigError < StandardError; end
 

--- a/lib/wachtwoord/manager.rb
+++ b/lib/wachtwoord/manager.rb
@@ -9,6 +9,7 @@
 module Wachtwoord
   class Manager
     extend T::Sig
+
     SECRET_KEY = :value
 
     sig { params(secret: Secret, client: T.untyped).void }

--- a/lib/wachtwoord/secret.rb
+++ b/lib/wachtwoord/secret.rb
@@ -7,6 +7,7 @@ module Wachtwoord
     extend Forwardable
     extend T::Sig
     include Comparable
+
     NAMESPACE_SEPARATOR = '/'
     class NilSecretName < StandardError; end
 

--- a/lib/wachtwoord/secret_name_matcher.rb
+++ b/lib/wachtwoord/secret_name_matcher.rb
@@ -4,8 +4,10 @@
 module Wachtwoord
   class SecretNameMatcher
     extend T::Sig
+
     class << self
       extend T::Sig
+
       sig { params(token: String).returns(Regexp) }
       def token_to_pattern(token)
         /(\b|_)(#{token})(\b|_)/i

--- a/lib/wachtwoord/version_stage.rb
+++ b/lib/wachtwoord/version_stage.rb
@@ -8,6 +8,7 @@ module Wachtwoord
 
     class << self
       extend T::Sig
+
       sig { params(version_number: T.nilable(Integer)).returns(String) }
       def serialized_version_stage(version_number:)
         "#{Wachtwoord.configuration.version_stage_prefix}#{version_number.to_s.rjust(3, '0')}"

--- a/test/test_wachtwoord.rb
+++ b/test/test_wachtwoord.rb
@@ -37,6 +37,18 @@ class TestWachtwoord < Minitest::Test
     unset_envs
   end
 
+  def test_load_secrets_into_env_preserve_existing_forced_overwrite
+    set_envs
+    expect_fetch
+    described_class.configuration.forced_overwrite_config_names = ['BLAH2']
+    described_class.load_secrets_into_env(clash_behaviour: :preserve_env)
+
+    assert_equal('blah', ENV.fetch('BLAH1', nil)) # Sets the new ENV
+    assert_equal('unexpected', ENV.fetch('BLAH2', nil)) # BLAH2 is in the forced overwrite list, so overwrites still
+  ensure
+    unset_envs
+  end
+
   def test_load_secrets_into_env_overwrite_existing
     set_envs
     expect_fetch


### PR DESCRIPTION
We encountered an interesting quirk of Heroku buildpacks - they set certain ENVs in the image they produce:

https://github.com/heroku/buildpacks-ruby/blob/014dd2694a6b5177a4e924f86640b37da6299977/buildpacks/ruby/src/steps/default_env.rs#L50-L58

Then, when we're running wachtwoord in `preserve_env` mode, it will not be able to override those ENVs. That's fine for most of those ENVs as we can simply override them in our HelmRelease (https://github.com/meetcleo/cleo-flux/blob/main/cleo-mlops/staging/monolith/monolith.yaml#L48-L55), but SECRET_KEY_BASE is not a config value, it's a secret, so we can't use that approach.

This PR introduces the option to still overwrite certain ENVs even when running in preserve_env mode, which can be set with the WACHTWOORD_FORCED_OVERWRITE_CONFIG_NAMES env var.