### PR TITLE
[PLT-XXX] Move loading secrets from before_configuration block

### DIFF
--- a/lib/wachtwoord.rb
+++ b/lib/wachtwoord.rb
@@ -41,6 +41,16 @@ module Wachtwoord
       configuration
     end
 
+    sig { void }
+    def load_secrets
+      return unless configuration.enabled
+
+      start_at = Time.now
+      load_secrets_into_env(clash_behaviour: :preserve_env)
+      end_at = Time.now
+      configuration.logger.info("[Wachtwoord] loaded secrets in #{end_at - start_at}s")
+    end
+
     sig { params(name: String, override_namespace: T.nilable(String), blk: T.proc.params(arg0: Manager).returns(Manager)).returns([String, Integer]) }
     def add_or_update(name:, override_namespace: nil, &blk)
       secret = Secret.new(name:, override_namespace:)

--- a/lib/wachtwoord/railtie.rb
+++ b/lib/wachtwoord/railtie.rb
@@ -12,14 +12,5 @@ module Wachtwoord
         config.logger = Rails.logger
       end
     end
-
-    config.before_configuration do
-      next unless Wachtwoord.configuration.enabled
-
-      start_at = Time.now
-      Wachtwoord.load_secrets_into_env(clash_behaviour: :preserve_env)
-      end_at = Time.now
-      Wachtwoord.configuration.logger.info("[Wachtwoord] loaded secrets in #{end_at - start_at}s")
-    end
   end
 end

--- a/lib/wachtwoord/version.rb
+++ b/lib/wachtwoord/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Wachtwoord
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
We want to control when Wachtwoord secrets are loaded so we can call it after Secret envs are unset in
readonly environments.